### PR TITLE
Build it with the "org.embulk.embulk-plugins" Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "com.jfrog.bintray" version "1.1"
     id "java"
     id "checkstyle"
     id "maven-publish"
@@ -20,7 +19,7 @@ targetCompatibility = 1.8
 
 dependencies {
     compileOnly  "org.embulk:embulk-core:0.9.23"
-    compile("io.github.medjed:JsonPathCompiler:0.1.+") {
+    compile("io.github.medjed:JsonPathCompiler:0.1.2") {
         exclude group: "org.apache.commons", module: "commons-lang3"
         exclude group: "org.slf4j", module: "slf4j-api"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,83 +1,72 @@
 plugins {
     id "com.jfrog.bintray" version "1.1"
-    id "com.github.jruby-gradle.base" version "1.5.0"
     id "java"
     id "checkstyle"
+    id "maven-publish"
+    id "org.embulk.embulk-plugins" version "0.4.2"
 }
-import com.github.jrubygradle.JRubyExec
+
 repositories {
     mavenCentral()
     jcenter()
 }
-configurations {
-    provided
-}
 
+group = "io.github.sonots"
 version = "0.3.3"
+description = "A filter plugin for Embulk to change timestamp format."
+
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 dependencies {
-    compile  "org.embulk:embulk-core:0.9.12"
-    provided "org.embulk:embulk-core:0.9.12"
-    compile  "io.github.medjed:JsonPathCompiler:0.1.+"
+    compileOnly  "org.embulk:embulk-core:0.9.23"
+    compile("io.github.medjed:JsonPathCompiler:0.1.+") {
+        exclude group: "org.apache.commons", module: "commons-lang3"
+        exclude group: "org.slf4j", module: "slf4j-api"
+    }
 
+    testCompile  "org.embulk:embulk-core:0.9.23:tests"
+    testCompile  "org.embulk:embulk-standards:0.9.23"
+    // TODO: Remove them.
+    // These `testCompile` are a tentative workaround. It will be covered in Embulk core's testing mechanism.
+    testCompile "org.embulk:embulk-deps-buffer:0.9.23"
+    testCompile "org.embulk:embulk-deps-config:0.9.23"
     testCompile "junit:junit:4.+"
-    testCompile "org.embulk:embulk-core:0.9.12:tests"
 }
 
 checkstyle {
     toolVersion = '6.7'
 }
 
-task classpath(type: Copy, dependsOn: ["jar"]) {
-    doFirst { file("classpath").deleteDir() }
-    from (configurations.runtime - configurations.provided + files(jar.archivePath))
-    into "classpath"
-}
-clean { delete "classpath" }
-
-task gem(type: JRubyExec, dependsOn: ["gemspec", "classpath"]) {
-    jrubyArgs "-S"
-    script "gem"
-    scriptArgs "build", "${project.name}.gemspec"
-    doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "pkg") }
+embulkPlugin {
+    mainClass = "org.embulk.filter.timestamp_format.TimestampFormatFilterPlugin"
+    category = "filter"
+    type = "timestamp_format"
 }
 
-task gemPush(type: JRubyExec, dependsOn: ["gem"]) {
-    jrubyArgs "-S"
-    script "gem"
-    scriptArgs "push", "pkg/${project.name}-${project.version}.gem"
+// TODO: enable when the pure-java plugin publish.
+//publishing {
+//    publications {
+//        embulkPluginMaven(MavenPublication) {  // Publish it with "publishEmbulkPluginMavenPublicationToMavenRepository".
+//            from components.java  // Must be "components.java". The dependency modification works only for it.
+//        }
+//    }
+//    repositories {
+//        maven {
+//            url = "${project.buildDir}/mavenPublishLocal"
+//        }
+//    }
+//}
+
+gem {
+    from("LICENSE.txt")
+    authors = [ "Naotoshi Seo" ]
+    email = [ "sonots@gmail.com" ]
+    summary = "A filter plugin for Embulk to change timestamp format"
+    homepage = "https://github.com/sonots/embulk-filter-timestamp_format"
+    licenses = [ "MIT" ]
 }
 
-task "package"(dependsOn: ["gemspec", "classpath"]) << {
-    println "> Build succeeded."
-    println "> You can run embulk with '-L ${file(".").absolutePath}' argument."
+gemPush {
+    host = "https://rubygems.org"
 }
-
-task gemspec {
-    ext.gemspecFile = file("${project.name}.gemspec")
-    inputs.file "build.gradle"
-    outputs.file gemspecFile
-    doLast { gemspecFile.write($/
-Gem::Specification.new do |spec|
-  spec.name          = "${project.name}"
-  spec.version       = "${project.version}"
-  spec.authors       = ["Naotoshi Seo"]
-  spec.summary       = %[A filter plugin for Embulk to change timestamp format]
-  spec.description   = %[A filter plugin for Embulk to change timestamp format.]
-  spec.email         = ["sonots@gmail.com"]
-  spec.licenses      = ["MIT"]
-  spec.homepage      = "https://github.com/sonots/embulk-filter-timestamp_format"
-
-  spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"]
-  spec.test_files    = spec.files.grep(%r"^(test|spec)/")
-  spec.require_paths = ["lib"]
-
-  spec.add_development_dependency 'bundler', ['~> 1.0']
-  spec.add_development_dependency 'rake', ['>= 10.0']
-end
-/$)
-    }
-}
-clean { delete "${project.name}.gemspec" }

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+io.github.medjed:JsonPathCompiler:0.1.2
+net.minidev:accessors-smart:1.1
+net.minidev:json-smart:2.2.1
+org.ow2.asm:asm:5.0.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -8,13 +8,13 @@
 @rem Set local scope for the variables with windows NT shell
 if "%OS%"=="Windows_NT" setlocal
 
-@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
-
 set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome
@@ -46,10 +46,9 @@ echo location of your Java installation.
 goto fail
 
 :init
-@rem Get command-line arguments, handling Windowz variants
+@rem Get command-line arguments, handling Windows variants
 
 if not "%OS%" == "Windows_NT" goto win9xME_args
-if "%@eval[2+2]" == "4" goto 4NT_args
 
 :win9xME_args
 @rem Slurp the command line arguments.
@@ -60,11 +59,6 @@ set _SKIP=2
 if "x%~1" == "x" goto execute
 
 set CMD_LINE_ARGS=%*
-goto execute
-
-:4NT_args
-@rem Get arguments from the 4NT Shell from JP Software
-set CMD_LINE_ARGS=%$
 
 :execute
 @rem Setup the command line

--- a/lib/embulk/filter/timestamp_format.rb
+++ b/lib/embulk/filter/timestamp_format.rb
@@ -1,3 +1,0 @@
-Embulk::JavaPlugin.register_filter(
-  "timestamp_format", "org.embulk.filter.timestamp_format.TimestampFormatFilterPlugin",
-  File.expand_path('../../../../classpath', __FILE__))


### PR DESCRIPTION
This PR changes to a new development style using [`gradle-embulk-plugins`.](http://github.com/embulk/gradle-embulk-plugins)
It requires the following reasons.

* Embulk core is changing some of Embulk API/SPI.
* Bintray (the repository embulk-core) will shut down the service. All plugin requires to use another repository.

This PR is the first step to migrate.

I read [this comment](https://github.com/sonots/embulk-filter-column/pull/23#pullrequestreview-373383180). So, I set the Maven group name to `io.github.sonots`

@dmikurube, Could you review this PR?

@sonots Could you review this PR after @dmikurube review?